### PR TITLE
Add immersive:// URL Scheme

### DIFF
--- a/OpenImmersiveApp/Info.plist
+++ b/OpenImmersiveApp/Info.plist
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLIconFile</key>
+			<string>openimmersive-logo</string>
+			<key>CFBundleURLName</key>
+			<string>com.acuteimmersive.openimmersive</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>immersive</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>

--- a/OpenImmersiveApp/OpenImmersiveApp.swift
+++ b/OpenImmersiveApp/OpenImmersiveApp.swift
@@ -11,11 +11,16 @@ import OpenImmersive
 @main
 struct OpenImmersiveApp: App {
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.dismissWindow) private var dismissWindow
     @Environment(\.dismissImmersiveSpace) private var dismissImmersiveSpace
+    @Environment(\.openImmersiveSpace) private var openImmersiveSpace
     
     var body: some Scene {
         WindowGroup(id: "MainWindow") {
             MainMenu()
+                .onOpenURL { url in
+                    handleOpenUrl(url)
+                }
         }
         .defaultSize(width: 750, height: 600)
         
@@ -28,5 +33,33 @@ struct OpenImmersiveApp: App {
             }
         }
         .immersionStyle(selection: .constant(.full), in: .full)
+    }
+
+    func handleOpenUrl(_ url: URL) {
+        switch url.host() {
+        case "open-stream":
+            Task {
+                guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return }
+                guard let parsedStreamUrl = components.queryItems?.first(where: { $0.name == "url" })!.value else { return }
+                guard let url = URL(string: parsedStreamUrl) else { return }
+                
+                let title = components.queryItems?.first(where: { $0.name == "title" })?.value ?? "Stream"
+                let details = components.queryItems?.first(where: { $0.name == "details" })?.value ?? ""
+                
+                let stream = StreamModel(
+                    title: title,
+                    details: details,
+                    url: url,
+                    isSecurityScoped: false
+                )
+                
+                let result = await openImmersiveSpace(value: stream)
+                if result == .opened {
+                    dismissWindow(id: "MainWindow")
+                }
+            }
+        default:
+            break;
+        }
     }
 }


### PR DESCRIPTION
This change adds support for using the immersive:// URL scheme to launch OpenImmersive app and start the video player.

See demo video of the feature here:

https://drive.google.com/file/d/1nW3GcOHN7_1IPAo604OJBfi6XBENL894/view?usp=sharing

The [URL used for testing](https://visitnyc.store/test-openimmersive.html) contains HTML `<a href="immersive://open-stream?url=...">` with various URL fields declared.

- The `url` query parameter is required
- The `title` query parameter is not required but will default to "Stream" if left empty
- The `details` query parameter is optional.

Questions to consider before ready to merge:

- Should the `handleOpenUrl` be placed somewhere else?
- What about the `immersive://` name? `openimmersive://` ?
- Same for the path, `open-stream` is that the right name?