### PR TITLE
Update demo playback to showcase subtitle/caption support

### DIFF
--- a/OpenImmersiveApp/OpenImmersiveApp.swift
+++ b/OpenImmersiveApp/OpenImmersiveApp.swift
@@ -96,7 +96,7 @@ struct OpenImmersiveApp: App {
             let customButton: CustomViewBuilder = { _ in
                 TimecodeToggle(isOn: $appState.showTimecodeReadout)
             }
-            let customAttachment = CustomAttachment(
+            let timecodeAttachment = CustomAttachment(
                 id: "TimecodeReadout",
                 body: { $videoPlayer in
                     TimecodeReadout(videoPlayer: videoPlayer, visible: $appState.showTimecodeReadout)
@@ -110,7 +110,7 @@ struct OpenImmersiveApp: App {
                 selectedItem: model!,
                 closeAction: closeAction,
                 customButtons: customButton,
-                customAttachments: [customAttachment]
+                customAttachments: [timecodeAttachment],
             )
         }
         .immersionStyle(selection: .constant(.full), in: .full)

--- a/OpenImmersiveApp/Views/SourcesList.swift
+++ b/OpenImmersiveApp/Views/SourcesList.swift
@@ -182,7 +182,8 @@ extension VideoItem {
             .commonIdentifierDescription: "Local basketball player takes a shot at sunset",
         ],
         url: URL(string: "https://stream.spatialgen.com/stream/JNVc-sA-_QxdOQNnzlZTc/index.m3u8")!,
-        projection: .equirectangular(fieldOfView: 180.0)
+        projection: .equirectangular(fieldOfView: 180.0),
+        subtitleURL: Bundle.main.url(forResource: "sample_subtitles", withExtension: "vtt", subdirectory: "TestAssets")
     )
 }
 

--- a/TestAssets/README.md
+++ b/TestAssets/README.md
@@ -1,0 +1,27 @@
+# Test Assets
+
+This directory contains test assets for the OpenImmersive project.
+
+## Sample Subtitle Files
+
+### sample_subtitles.srt
+SubRip (.srt) format subtitle file for testing the caption system.
+
+### sample_subtitles.vtt
+WebVTT (.vtt) format subtitle file for testing the caption system.
+
+## How to Use
+
+1. Open the OpenImmersive app in visionOS
+2. Load a video
+3. Tap the CC (closed caption) button in the control panel
+4. Select one of the sample subtitle files
+5. Subtitles will appear at the bottom of your immersive view
+
+## Supported Formats
+
+The subtitle system supports:
+- SRT (SubRip)
+- VTT/WebVTT
+- SBV (YouTube SubViewer)
+- SSA/ASS (Advanced SubStation Alpha)

--- a/TestAssets/sample_subtitles.srt
+++ b/TestAssets/sample_subtitles.srt
@@ -1,0 +1,27 @@
+1
+00:00:00,000 --> 00:00:03,000
+Welcome to the immersive video experience
+
+2
+00:00:03,500 --> 00:00:07,000
+This is a sample subtitle file
+
+3
+00:00:07,500 --> 00:00:11,000
+Testing the caption display system
+
+4
+00:00:11,500 --> 00:00:15,000
+Subtitles appear at the bottom of your view
+
+5
+00:00:15,500 --> 00:00:19,000
+Tap the CC button to load subtitle files
+
+6
+00:00:19,500 --> 00:00:23,000
+Supports SRT, WebVTT, and other formats
+
+7
+00:00:23,500 --> 00:00:27,000
+Enjoy your immersive video!

--- a/TestAssets/sample_subtitles.vtt
+++ b/TestAssets/sample_subtitles.vtt
@@ -1,0 +1,22 @@
+WEBVTT
+
+00:00.000 --> 00:03.000
+Welcome to the immersive video experience
+
+00:03.500 --> 00:07.000
+This is a WebVTT subtitle file
+
+00:07.500 --> 00:11.000
+Testing the caption display system
+
+00:11.500 --> 00:15.000
+Subtitles appear at the bottom of your view
+
+00:15.500 --> 00:19.000
+Tap the CC button to load subtitle files
+
+00:19.500 --> 00:23.000
+Supports SRT, WebVTT, and other formats
+
+00:23.500 --> 00:27.000
+Enjoy your immersive video!


### PR DESCRIPTION
Updated demo to correlate with library updates currently PR'ed at: https://github.com/acuteimmersive/openimmersivelib/pull/29

Not included in this PR is all the Xcode configuration changes required to locally build [openimmersivelib](https://github.com/acuteimmersive/openimmersivelib). It's assumed that whoever wants to test this will know how to point it at the correct tag/local build.

Changes:

1. Expose the bundled subtitle URL so the CC button has content to load
2. Added a TestAssets folder with SRT/VTT samples plus README steps so the caption system can be exercised and documented in the demo
3. Update the demo to the newer VideoItem pipeline, load the bundled HLS sample with a subtitle URL, and ship WebVTT/SRT assets plus guidance so the caption/CC workflow can be manually verified.

<img width="375" height="261" alt="Screenshot 2025-12-17 at 5 21 54 PM" src="https://github.com/user-attachments/assets/03a2388b-0537-4b12-a621-90da6b2cd78c" />


https://github.com/user-attachments/assets/193d6992-20c7-4ec5-bd60-e79b26bd0916

